### PR TITLE
gitee mirror sync

### DIFF
--- a/.github/workflows/gitee-repo-mirror.yml
+++ b/.github/workflows/gitee-repo-mirror.yml
@@ -1,0 +1,24 @@
+name: Gitee repos mirror periodic job
+on:
+  push: 
+    branches: [ master ]
+  pull_request: 
+    branches: [ master ]
+  #schedule:
+  #  # 每天北京时间9点跑
+  #  - cron:  '0 1 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror the Github organization repos to Gitee.
+        uses: Yikun/hub-mirror-action@master
+        with:
+          src: github/loyalpartner
+          dst: gitee/bbblili
+          dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+          dst_token: ${{ secrets.GITEE_TOKEN }}
+          static_list: "emacs-application-framework"
+          debug: true
+
+

--- a/.github/workflows/gitee-repo-mirror.yml
+++ b/.github/workflows/gitee-repo-mirror.yml
@@ -1,12 +1,9 @@
 name: Gitee repos mirror periodic job
 on:
-  push: 
-    branches: [ master ]
-  pull_request: 
-    branches: [ master ]
-  #schedule:
-  #  # 每天北京时间9点跑
-  #  - cron:  '0 1 * * *'
+  push:
+  schedule:
+    # 每天北京时间9点跑
+    - cron:  '0 1 * * *'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,5 +17,3 @@ jobs:
           dst_token: ${{ secrets.GITEE_TOKEN }}
           static_list: "emacs-application-framework"
           debug: true
-
-

--- a/.github/workflows/gitee-repo-mirror.yml
+++ b/.github/workflows/gitee-repo-mirror.yml
@@ -1,6 +1,9 @@
 name: Gitee repos mirror periodic job
 on:
   push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   schedule:
     # 每天北京时间9点跑
     - cron:  '0 1 * * *'
@@ -11,9 +14,10 @@ jobs:
       - name: Mirror the Github organization repos to Gitee.
         uses: Yikun/hub-mirror-action@master
         with:
-          src: github/loyalpartner
-          dst: gitee/bbblili
+          src: github/emacs-eaf
+          dst: gitee/emacs-eaf
           dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
           dst_token: ${{ secrets.GITEE_TOKEN }}
           static_list: "emacs-application-framework"
+          account_type: org
           debug: true


### PR DESCRIPTION
## 需要配置两个 secret 环境变量

- `GITEE_PRIVATE_KEY` 用于在目的端上传代码的私钥(默认可以从~/.ssh/id_rsa获取），可参考[生成/添加SSH公钥](https://gitee.com/help/articles/4181)或[generating SSH keys](https://docs.github.com/articles/generating-an-ssh-key/)生成，并确认对应公钥已经被正确配置在目的端。对应公钥，Github可以在[这里](https://github.com/settings/keys)配置，Gitee可以[这里](https://gitee.com/profile/sshkeys)配置。
- `GITEE_TOKEN` 创建仓库的API tokens， 用于自动创建不存在的仓库，Github可以在[这里](https://github.com/settings/tokens)找到，Gitee可以在[这里](https://gitee.com/profile/personal_access_tokens)找到。

## 设置方法
项目主页依次点击： Settings --> Secrets --> New repository secret