### PR TITLE
Ctrl + Mouse Back/Forward to switch to next/previous webpage buffer

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -246,12 +246,21 @@ class BrowserView(QWebEngineView):
                 eval_in_emacs('eaf-activate-emacs-window', [])
 
             if event.button() == MOUSE_FORWARD_BUTTON:
-                self.forward()
+                modifiers = QApplication.keyboardModifiers()
+                if modifiers == Qt.ControlModifier:
+                    self.switch_to_next_webpage_buffer()
+                else:
+                    self.forward()
 
                 event.accept()
                 return True
+
             elif event.button() == MOUSE_BACK_BUTTON:
-                self.back()
+                modifiers = QApplication.keyboardModifiers()
+                if modifiers == Qt.ControlModifier:
+                    self.switch_to_previous_webpage_buffer()
+                else:
+                    self.back()
 
                 event.accept()
                 return True
@@ -310,6 +319,18 @@ class BrowserView(QWebEngineView):
     def open_url_background_buffer(self, url):
         ''' Open url in background tab.'''
         open_url_in_background_tab(url)
+
+        eval_in_emacs('eaf-activate-emacs-window', [])
+
+    def switch_to_next_webpage_buffer(self):
+        ''' Switch to next web page buffer.'''
+        eval_in_emacs('eaf-next-buffer-same-app', [])
+
+        eval_in_emacs('eaf-activate-emacs-window', [])
+
+    def switch_to_previous_webpage_buffer(self):
+        ''' Switch to previous web page buffer.'''
+        eval_in_emacs('eaf-previous-buffer-same-app', [])
 
         eval_in_emacs('eaf-activate-emacs-window', [])
 

--- a/eaf.el
+++ b/eaf.el
@@ -1448,6 +1448,26 @@ You can configure a blacklist using `eaf-find-file-ext-blacklist'"
        (eaf--match-app-extension-p (downcase ext))
        (not (member ext eaf-find-file-ext-blacklist))))
 
+(defun eaf-next-buffer-same-app ()
+  "Switch to the next buffer of the same EAF app with the current buffer."
+  (interactive)
+  (let ((origin-buff (current-buffer)) (app-name mode-name)
+        (new-buff nil) (finished nil))
+    (while (not finished)
+      (setq new-buff (next-buffer))
+      (when (or (equal new-buff origin-buff) (equal app-name mode-name))
+        (setq finished t)))))
+
+(defun eaf-previous-buffer-same-app ()
+  "Switch to the previous buffer of the same EAF app with the current buffer."
+  (interactive)
+  (let ((origin-buff (current-buffer)) (app-name mode-name)
+        (new-buff nil) (finished nil))
+    (while (not finished)
+      (setq new-buff (previous-buffer))
+      (when (or (equal new-buff origin-buff) (equal app-name mode-name))
+        (setq finished t)))))
+
 ;;;;;;;;;;;;;;;;;;;; Advice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; FIXME: In the code below we should use `save-selected-window' (or even


### PR DESCRIPTION
Hi,

I implemented this feature to allow using Ctrl + Mouse Backward/Forward buttons to switch to the previous/next webpage buffers in the same Emacs window. 

It is different from the current Mouse Backward/Forward feature in that the latter only switch pages of the same buffer.

It is useful when a user wants to open many webpage buffers and navigate between them.

Could you advise if it is necessary to be included in EAF?

Thanks!