### PR TITLE
find focusing buffer on all visible frames

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1044,7 +1044,7 @@ of `eaf--buffer-app-name' inside the EAF buffer."
   (catch 'found-eaf
     (eaf-for-each-eaf-buffer
      (when (string= eaf--buffer-id focus-buffer-id)
-       (let ((buffer-window (get-buffer-window buffer)))
+       (let ((buffer-window (get-buffer-window buffer 'visible)))
          (when buffer-window
            (select-window buffer-window)))
        (throw 'found-eaf t)))))


### PR DESCRIPTION
Hi,

I created this patch to fix a bug that EAF gets focus on the wrong window buffer when a user who is
- running Emacs in daemon mode with 2 frames
- working in one active frame
- and wants to click on a webpage link in the other frame.

The current code only finds the window buffer `(get-buffer-window buffer)` on the selected frame (the first frame). This isn't the correct frame, hence EAF cannot get the correct focus on the other frame containing the webpage.

I updated the new code to `(get-buffer-window buffer 'visible)` to enable EAF to find in the other frame as well.

Could you advise if this is a suitable fix?

Thanks!

