### PR TITLE
gain EAF buffer focus by do_nothing, instead of move_cursor_to_corner

### DIFF
--- a/core/buffer.py
+++ b/core/buffer.py
@@ -179,6 +179,12 @@ class Buffer(QGraphicsScene):
         screen = qApp.primaryScreen()
         QCursor().setPos(screen, screen.size().width(), screen.size().height())
 
+    def do_nothing(self):
+        '''
+        Do nothing
+        '''
+        return True
+
     def set_aspect_ratio(self, aspect_ratio):
         ''' Set aspect ratio.'''
         self.aspect_ratio = aspect_ratio

--- a/eaf.el
+++ b/eaf.el
@@ -1323,7 +1323,7 @@ So multiple EAF buffers visiting the same file do not sync with each other."
   (when (and eaf-browser-fullscreen-move-cursor-corner
              (or (string= eaf--buffer-app-name "browser")
                  (string= eaf--buffer-app-name "js-video-player")))
-    (eaf-call-async "execute_function" eaf--buffer-id "move_cursor_to_corner" (key-description (this-command-keys-vector)))))
+    (eaf-call-async "execute_function" eaf--buffer-id "do_nothing" (key-description (this-command-keys-vector)))))
 
 ;; Update and load the theme
 (defun eaf-get-theme-mode ()
@@ -1377,7 +1377,7 @@ So multiple EAF buffers visiting the same file do not sync with each other."
       ;; Emacs window cannot get the focus normally if mouse in EAF buffer area.
       ;;
       ;; So we move mouse to frame bottom of Emacs, to make EAF receive input event.
-      (eaf-call-async "execute_function" (or eaf--buffer-id buffer_id) "move_cursor_to_corner" (key-description (this-command-keys-vector)))
+      (eaf-call-async "execute_function" (or eaf--buffer-id buffer_id) "do_nothing" (key-description (this-command-keys-vector)))
 
     ;; When press Alt + Tab in DE, such as KDE.
     ;; Emacs window cannot get the focus normally if mouse in EAF buffer area.


### PR DESCRIPTION
Hi,

I created this PR based on our discussion here: https://github.com/emacs-eaf/emacs-application-framework/pull/796#issuecomment-901762463