### PR TITLE
[discuss] Add eaf-read-marker-letters and use it.

### DIFF
--- a/core/buffer.py
+++ b/core/buffer.py
@@ -243,7 +243,7 @@ class Buffer(QGraphicsScene):
 
         CALLBACK_TAG is the reference tag when handle_input_message is invoked.
 
-        INPUT_TYPE must be one of "string", "file", or "yes-or-no".
+        INPUT_TYPE must be one of "marker-letters" "string", "file", or "yes-or-no".
 
         INITIAL_CONTENT is the intial content of the user response, it is only useful when INPUT_TYPE is "string".
         '''

--- a/core/webengine.py
+++ b/core/webengine.py
@@ -1156,25 +1156,25 @@ class BrowserBuffer(Buffer):
     def open_link(self):
         ''' Open Link through a marker.'''
         self.buffer_widget.get_link_markers()
-        self.send_input_message("Open Link: ", "open_link");
+        self.send_input_message("Open Link: ", "open_link", "marker-letters");
 
     @interactive(insert_or_do=True)
     def open_link_new_buffer(self):
         ''' Open Link in New Buffer.'''
         self.buffer_widget.get_link_markers()
-        self.send_input_message("Open Link in New Buffer: ", "open_link_new_buffer");
+        self.send_input_message("Open Link in New Buffer: ", "open_link_new_buffer", "marker-letters");
 
     @interactive(insert_or_do=True)
     def open_link_new_buffer_other_window(self):
         ''' Open Link in New Buffer in Other Window.'''
         self.buffer_widget.get_link_markers()
-        self.send_input_message("Open Link in New Buffer in Other Window: ", "open_link_new_buffer_other_window");
+        self.send_input_message("Open Link in New Buffer in Other Window: ", "open_link_new_buffer_other_window", "marker-letters");
 
     @interactive(insert_or_do=True)
     def open_link_background_buffer(self):
         ''' Open Link in Background Buffer.'''
         self.buffer_widget.get_link_markers()
-        self.send_input_message("Open Link in Background Buffer: ", "jump_link_background_buffer");
+        self.send_input_message("Open Link in Background Buffer: ", "jump_link_background_buffer", "marker-letters");
 
     @interactive
     def copy_link(self):

--- a/eaf.el
+++ b/eaf.el
@@ -374,7 +374,11 @@ been initialized."
   "Directory where eaf will store configuration files."
   :type 'directory)
 
-(defcustom eaf-marker-letters "ASDFHJKLWEOPCNM"
+(defcustom eaf-marker-letters "ASDHJKLWEOPCNM"
+  ""
+  :type 'string)
+
+(defcustom eaf-marker-finish-letters "F "
   ""
   :type 'string)
 
@@ -1168,8 +1172,32 @@ WEBENGINE-INCLUDE-PRIVATE-CODEC is only useful when app-name is video-player."
             ((string-equal interactive-type "file")
              (expand-file-name (read-file-name interactive-string)))
             ((string-equal interactive-type "yes-or-no")
-             (yes-or-no-p interactive-string)))
+             (yes-or-no-p interactive-string))
+            ((string-equal interactive-type "marker-letters")
+             (eaf-read-marker-letters interactive-string initial-content)))
     (quit nil)))
+
+(defun eaf-read-marker-letters (interactive-string initial-content)
+  "Read marker letters."
+  (read-from-minibuffer
+   interactive-string nil
+   (let ((map (copy-keymap minibuffer-local-map))
+         (marker-letters
+          (string-to-list (downcase eaf-marker-letters)))
+         (marker-finish-letters
+          (string-to-list (downcase eaf-marker-finish-letters)))
+         (i ?\ ))
+     (while (< i 127)
+       (define-key map (char-to-string i)
+         `(lambda ()
+            (interactive)
+            (cond ((member ,i ',marker-letters)
+                   (self-insert-command 1))
+                  ((member ,i ',marker-finish-letters)
+                   (exit-minibuffer))
+                  (t nil))))
+       (setq i (1+ i)))
+     map)))
 
 (defun eaf--open-internal (url app-name args)
   "Open an EAF application internally with URL, APP-NAME and ARGS."


### PR DESCRIPTION
这个功能主要是优化 marker 输入的。
1. 在浏览器中按 f 后输入marker， 再按f可以当回车使用
2. f 可以实现toggle 的功能
3. 输入 marker 的时候，只允许输入合法的 marker letter。
4. 按 I 键后，可以进入编辑模式，输入任意字符串。