### PR TITLE
allow edit_url to search string

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -233,6 +233,21 @@ def eval_in_emacs(method_name, args):
         # Call eval-in-emacs elisp function.
         epc_client.call("eval-in-emacs", args)
 
+def eval_get_result_in_emacs(method_name, args):
+    global epc_client
+
+    if epc_client == None:
+        print("Please call init_epc_client first before callling eval_in_emacs.")
+    else:
+        args = list(map(convert_arg_to_str, args))
+        # Make argument encode with Base64, avoid string quote problem pass to elisp side.
+        args = list(map(string_to_base64, args))
+
+        args.insert(0, method_name)
+
+        # Call eval-in-emacs elisp function.
+        return epc_client.call_sync("eval-in-emacs", args)
+
 def get_emacs_vars(args):
     global epc_client
 

--- a/core/webengine.py
+++ b/core/webengine.py
@@ -27,7 +27,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineS
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWebChannel import QWebChannel
 from core.buffer import Buffer
-from core.utils import touch, string_to_base64, popen_and_call, call_and_check_code, interactive, abstract, eval_in_emacs, message_to_emacs, clear_emacs_message, open_url_in_background_tab, duplicate_page_in_new_tab, open_url_in_new_tab, open_url_in_new_tab_other_window, focus_emacs_buffer, atomic_edit, get_emacs_config_dir, to_camel_case, get_emacs_vars
+from core.utils import touch, string_to_base64, popen_and_call, call_and_check_code, interactive, abstract, eval_in_emacs, eval_get_result_in_emacs, message_to_emacs, clear_emacs_message, open_url_in_background_tab, duplicate_page_in_new_tab, open_url_in_new_tab, open_url_in_new_tab_other_window, focus_emacs_buffer, atomic_edit, get_emacs_config_dir, to_camel_case, get_emacs_vars
 from functools import partial
 from urllib.parse import urlparse, parse_qs, urlunparse, urlencode
 import base64
@@ -302,7 +302,12 @@ class BrowserView(QWebEngineView):
 
     def open_url(self, url):
         ''' Configure current url.'''
-        self.setUrl(QUrl(url))
+        is_valid_url = eval_get_result_in_emacs('eaf-is-valid-web-url', [url])
+        if is_valid_url:
+            self.setUrl(QUrl(url))
+        else:
+            search_url = eval_get_result_in_emacs('eaf--create-search-url', [url])
+            self.setUrl(QUrl(search_url))
 
         eval_in_emacs('eaf-activate-emacs-window', [])
 


### PR DESCRIPTION
Hi,

I created this PR which allows users to search for a string when editing URL (`e`).

Currently, when a user presses `e` to edit the URL and just type `foo`, then EAF browser will return a blank page.
Using this PR, EAF can allow use to search for the string `foo` by using the default search engine.

This PR is accompanied by the PR https://github.com/emacs-eaf/eaf-browser/pull/9 in EAF browser.

Here, I need to create a new function `eval_get_result_in_emacs` to get the search string created by EAF browser.

Could you advise if this feature is useful and can be merged?

Thanks!