### PR TITLE
show message Emacs' echo area but not log to *Message* buffer when hovering links

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -257,6 +257,9 @@ def get_emacs_vars(args):
 def message_to_emacs(message):
     eval_in_emacs('eaf--show-message', [message])
 
+def message_to_emacs_no_logging(message):
+    eval_in_emacs('eaf--show-message-no-logging', [message])
+
 def clear_emacs_message():
     eval_in_emacs('eaf--clear-message', [])
 

--- a/core/webengine.py
+++ b/core/webengine.py
@@ -27,7 +27,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineS
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWebChannel import QWebChannel
 from core.buffer import Buffer
-from core.utils import touch, string_to_base64, popen_and_call, call_and_check_code, interactive, abstract, eval_in_emacs, message_to_emacs, clear_emacs_message, open_url_in_background_tab, duplicate_page_in_new_tab, open_url_in_new_tab, open_url_in_new_tab_other_window, focus_emacs_buffer, atomic_edit, get_emacs_config_dir, to_camel_case, get_emacs_vars
+from core.utils import touch, string_to_base64, popen_and_call, call_and_check_code, interactive, abstract, eval_in_emacs, message_to_emacs, message_to_emacs_no_logging, clear_emacs_message, open_url_in_background_tab, duplicate_page_in_new_tab, open_url_in_new_tab, open_url_in_new_tab_other_window, focus_emacs_buffer, atomic_edit, get_emacs_config_dir, to_camel_case, get_emacs_vars
 from functools import partial
 from urllib.parse import urlparse, parse_qs, urlunparse, urlencode
 import base64
@@ -294,7 +294,7 @@ class BrowserView(QWebEngineView):
 
         if self.show_hover_link:
             if url:
-                message_to_emacs(url)
+                message_to_emacs_no_logging(url)
             else:
                 clear_emacs_message()
 

--- a/eaf.el
+++ b/eaf.el
@@ -1093,6 +1093,15 @@ of `eaf--buffer-app-name' inside the EAF buffer."
                "[EAF] %s")))
     (message fmt format-string)))
 
+(defun eaf--show-message-no-logging (format-string)
+  "A wrapper around `message' that prepends [EAF/app-name] before FORMAT-STRING
+and does not log to the *Message* buffer."
+  (let ((fmt (if eaf--buffer-app-name
+                 (concat "[EAF/" eaf--buffer-app-name "] %s")
+               "[EAF] %s")))
+    (let ((message-log-max nil))
+      (message fmt format-string))))
+
 (defun eaf--clear-message ()
   "Clear Emacs' echo area ."
   (message nil))


### PR DESCRIPTION
Hi,

I created this PR to allow EAF to display URL links only in Emacs's echo area, but not log to the `*Message*` buffer when user hovers mouse over URL links in web-browser.

This is to prevent EAF from writing a lot of hovered links information (which is not really necessary to be logged into the `*Message*` buffer)

Note that `eaf-webengine-show-hover-link` needs to be set to `t` to enable the display of hovered links.

Can you advise if it is useful and can be merged?