### PR TITLE
Fix install-eaf.py to also work on Fedora

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -94,12 +94,12 @@ def run_command(command, path=script_path, ensure_pass=True, get_result=False):
 
 def install_sys_deps(distro: str, deps_list):
     command = []
-    if distro == 'pacman':
-        command = ['sudo', 'pacman', '-Sy', '--noconfirm']
+    if which("dnf"):
+        command = ['sudo', 'dnf', '-y', 'install']
     elif distro == 'apt':
         command = ['sudo', 'apt', '-y', 'install']
-    elif which("dnf"):
-        command = ['sudo', 'dnf', '-y', 'install']
+    elif distro == 'pacman':
+        command = ['sudo', 'pacman', '-Sy', '--noconfirm']
     elif which("pkg"):
         command = ['doas', 'pkg', '-y', 'install']
     elif which("zypper"):
@@ -183,14 +183,14 @@ def add_or_update_app(app: str, app_spec_dict):
 
 def get_distro():
     distro = ""
-    if which("pacman"):
+    if which("dnf"):
+        distro = "dnf"
+    elif which("apt"):
+        distro = "apt"
+    elif which("pacman"):
         distro = "pacman"
         if (not args.ignore_core_deps and not args.ignore_sys_deps and len(args.install) == 0) or args.install_core_deps:
             run_command(['sudo', 'pacman', '-Sy', '--noconfirm'])
-    elif which("apt"):
-        distro = "apt"
-    elif which("dnf"):
-        distro = "dnf"
     elif which("pkg"):
         distro = "pkg"
     elif which("zypper"):


### PR DESCRIPTION
On some (or all) Fedora installations, the pacman command is available so that
the install-eaf.py currently tries to use the pacman installer (trying to
installing the arch packages defined in the json file). This commit fixes it by
placing Fedora (dnf) before Arch (pacman) in the 'system check'.