### PR TITLE
unselect text, if any, on eaf-keyboard-quit

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -195,6 +195,8 @@ class BrowserView(QWebEngineView):
                 self.buffer.caret_toggle_mark()
             else:
                 self.buffer.caret_exit()
+        if self.web_page.hasSelection():
+            self.triggerPageAction(self.web_page.Unselect)
 
     def select_text_change(self):
         ''' Change selected text.'''


### PR DESCRIPTION
Hi,

This is a small improvement that allows eaf-browser to deselect the selected text when pressing C-g (eaf-keyboard-quit).