### PR TITLE
Fix dependencies for Fedora 35

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -22,6 +22,7 @@
         "glib2-devel",
         "python3-qt5",
         "python3-pyqt5-sip",
+        "python3-qt5-webengine",
         "pyqtwebengine-devel",
         "python3-pygit2"
     ],


### PR DESCRIPTION
I am not sure if maybe this package was already required on Fedora 34, but anyway it is now in F35. With this single addition, `emacs-application-framework` continues to work fine and to be awesome!

Also, I am not sure if `"pyqtwebengine-devel" is (and ever really was) required, the browser seems to work fine also after I uninstall this package. On the other hand, just keeping it will for sure do no harm.