### PR TITLE
fix bug in duplicating page

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -1273,7 +1273,7 @@ class BrowserBuffer(Buffer):
 
     @interactive(insert_or_do=True)
     def duplicate_page(self):
-        duplicate_page_in_new_tab(self.current_url)
+        duplicate_page_in_new_tab(self.url)
 
     @interactive(insert_or_do=True)
     def open_browser(self):


### PR DESCRIPTION
Hi,

The URL of the current page to be duplicated should be `self.url`, but not `current_url`.
`current_url` isn't updated anywhere in the code.