### PR TITLE
Add BlackWhiteList plugin for eaf-browser

### DIFF
--- a/core/black_white_proxy.py
+++ b/core/black_white_proxy.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+import re
+
+from PyQt5.QtNetwork import QNetworkProxy
+from PyQt5.QtWebEngineCore import QWebEngineUrlRequestInterceptor
+
+class BlackWhileListRequestInterceptor(QWebEngineUrlRequestInterceptor):
+    """
+    Proxy factory that enables non-default proxy list when
+    requested URL is matched by one of whitelist patterns
+    while not being matched by one of the blacklist patterns.
+    """
+    is_proxy = False
+
+    def __init__(self, proxy=None, blacklist=None, whitelist=None, parent=None):
+
+        self.proxy = proxy or None
+        self.blacklist = blacklist or []
+        self.whitelist = whitelist or []
+
+        if proxy:
+            self.proxy_policy = QNetworkProxy()
+            if proxy[0] == "socks5":
+                self.proxy_policy.setType(QNetworkProxy.Socks5Proxy)
+            elif proxy[0] == "http":
+                self.proxy_policy.setType(QNetworkProxy.HttpProxy)
+            self.proxy_policy.setHostName(proxy[1])
+            self.proxy_policy.setPort(int(proxy[2]))
+        else:
+            self.proxy_policy = None
+
+        self.default_policy = QNetworkProxy()
+        self.default_policy.setType(QNetworkProxy.NoProxy)
+
+
+        super().__init__(parent)
+
+    def shouldUseDefault(self, url):
+        if not self.proxy:
+            return True
+
+        if not self.is_proxy:
+            return True
+
+        if any(re.match(p, url) if isinstance(p, str) else False for p in self.blacklist):
+            return False
+
+        if any(re.match(p, url) if isinstance(p, str) else False for p in self.whitelist):
+            return True
+
+        return bool(self.blacklist)
+
+    def interceptRequest(self, info):
+        url = info.requestUrl().toString()
+
+        if self.shouldUseDefault(url):
+            if QNetworkProxy.applicationProxy() != self.default_policy:
+                QNetworkProxy.setApplicationProxy(self.default_policy)
+        else:
+            if QNetworkProxy.applicationProxy() != self.proxy_policy:
+                QNetworkProxy.setApplicationProxy(self.proxy_policy)

--- a/eaf.el
+++ b/eaf.el
@@ -414,6 +414,14 @@ been initialized."
   "Proxy Type used by EAF Browser.  The value is either \"http\" or \"socks5\"."
   :type 'string)
 
+(defcustom eaf-proxy-blacklist nil
+  "Proxy Blacklist used by EAF Browser."
+  :type 'list)
+
+(defcustom eaf-proxy-whilelist nil
+  "Proxy Bypass list used by EAF Browser."
+  :type 'list)
+
 (defcustom eaf-enable-debug nil
   "If you got segfault error, please turn this option.
 Then EAF will start by gdb, please send new issue with `*eaf*' buffer content when next crash."

--- a/eaf.py
+++ b/eaf.py
@@ -26,9 +26,10 @@ from PyQt5 import QtWebEngineWidgets as NeverUsed # noqa
 
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import QLibraryInfo, QTimer
-from PyQt5.QtNetwork import QNetworkProxy, QNetworkProxyFactory
+from PyQt5.QtNetwork import QNetworkProxyFactory
 from PyQt5.QtWidgets import QApplication
 from core.utils import PostGui, string_to_base64, eval_in_emacs, init_epc_client, close_epc_client, message_to_emacs, list_string_to_list, get_emacs_vars, get_emacs_config_dir, to_camel_case
+from core.black_white_proxy import BlackWhileListRequestInterceptor
 from core.view import View
 from epc.server import ThreadingEPCServer
 from sys import version_info
@@ -97,7 +98,6 @@ class EAF(object):
             "eaf-proxy-type"])
 
         self.proxy = (proxy_type, proxy_host, proxy_port)
-        self.is_proxy = False
 
         if proxy_type != "" and proxy_host != "" and proxy_port != "":
             self.enable_proxy()
@@ -106,31 +106,17 @@ class EAF(object):
         global proxy_string
 
         proxy_string = "{0}://{1}:{2}".format(self.proxy[0], self.proxy[1], self.proxy[2])
-
-        proxy = QNetworkProxy()
-        if self.proxy[0] == "socks5":
-            proxy.setType(QNetworkProxy.Socks5Proxy)
-        elif self.proxy[0] == "http":
-            proxy.setType(QNetworkProxy.HttpProxy)
-        proxy.setHostName(self.proxy[1])
-        proxy.setPort(int(self.proxy[2]))
-
-        self.is_proxy = True
-        QNetworkProxy.setApplicationProxy(proxy)
+        BlackWhileListRequestInterceptor.is_proxy = True
 
     def disable_proxy(self):
         global proxy_string
 
         proxy_string = ""
 
-        proxy = QNetworkProxy()
-        proxy.setType(QNetworkProxy.NoProxy)
-
-        self.is_proxy = False
-        QNetworkProxy.setApplicationProxy(proxy)
+        BlackWhileListRequestInterceptor.is_proxy = False
 
     def toggle_proxy(self):
-        if self.is_proxy:
+        if BlackWhileListRequestInterceptor.is_proxy:
             self.disable_proxy()
         else:
             self.enable_proxy()


### PR DESCRIPTION
A "crappy" proxy BlackWhiteList plugin for eaf browser base on QtNetworkProxyFactory

### Usage
```elisp
(setq eaf-proxy-blacklist '(".*google.com" ".*github\.com"))
# or
(setq eaf-proxy-whilelist '(".*baidu.com" ".*192\.168.*" ".*10\.0.*"))
```