### PR TITLE
Support Mac with ARM chip (#868)

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -360,6 +360,10 @@ been initialized."
 (defvar eaf-last-frame-height 0)
 
 (when (eq system-type 'darwin)
+  (defcustom eaf--mac-enable-rosetta nil
+    "Execute EAF Python process under Rosetta2"
+    :type 'boolean)
+
   (defvar eaf--mac-switch-to-python nil
     "Record if Emacs switchs to Python process")
 
@@ -601,9 +605,13 @@ A hashtable, key is url and value is title.")
       ;; Start python process.
       (let ((process-connection-type (not (eaf--called-from-wsl-on-windows-p))))
         (setq eaf-internal-process
-              (apply 'start-process
-                     eaf-name eaf-name
-                     eaf-internal-process-prog eaf-internal-process-args)))
+              (if eaf--mac-enable-rosetta
+                  (apply 'start-process
+                         eaf-name eaf-name
+                         "arch" (append (list "-x86_64" eaf-internal-process-prog) eaf-internal-process-args))
+                  (apply 'start-process
+                         eaf-name eaf-name
+                         eaf-internal-process-prog eaf-internal-process-args))))
       (set-process-query-on-exit-flag eaf-internal-process nil))))
 
 (run-with-idle-timer


### PR DESCRIPTION
- Use `arch -x86_64 python3 ./install-eaf.py` to install the x86 qt binary
- Set `eaf--mac-enable-rosetta` to execute the EAF python process under Rosetta2