### PR TITLE
Toggle Qt.WindowStaysOnTopHint on focus change instead of using the *eaf-temp* buffer

### DIFF
--- a/core/view.py
+++ b/core/view.py
@@ -145,6 +145,14 @@ class View(QWidget):
 
         qwindow.setPosition(QPoint(self.x, self.y))
 
+    def handle_emacs_focus_in(self):
+        self.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+        self.show()
+
+    def handle_emacs_focus_out(self):
+        self.setWindowFlag(Qt.WindowStaysOnTopHint, False)
+        self.hide()
+
     def destroy_view(self):
         # print("Destroy: ", self.buffer.url)
         self.destroy()

--- a/eaf.py
+++ b/eaf.py
@@ -468,6 +468,16 @@ class EAF(object):
                 for line in str(new_text).split("\n"):
                     buffer.add_texted_middle_node(line)
 
+    @PostGui()
+    def handle_emacs_focus_in(self):
+        for key in list(self.view_dict):
+            self.view_dict[key].handle_emacs_focus_in()
+
+    @PostGui()
+    def handle_emacs_focus_out(self):
+        for key in list(self.view_dict):
+            self.view_dict[key].handle_emacs_focus_out()
+
     def open_devtools_tab(self, web_page):
         ''' Open devtools tab'''
         self.devtools_page = web_page


### PR DESCRIPTION
Tagging @taquangtrung.

Maybe @lhpfvs can also take a look as the initial code with the temporary buffer was merged in https://github.com/emacs-eaf/emacs-application-framework/pull/616.
But I am not sure if the current code works with multiple frames as I don't need them on macOS.

Resolve #835 