### PR TITLE
Add eaf--mac-safe-focus-change to toggle between unsafe and safe focus change behavior

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -988,15 +988,15 @@ kxsgtn/ignore_spurious_focus_events_for/")
       (set-window-configuration
        (frame-parameter (selected-frame) 'eaf--mac-frame)))
 
-    (defun eaf--mac-unsafe-focus-out ()
+    (defun eaf--mac-unsafe-focus-out (&optional frame)
       (eaf-call-async "mac_handle_emacs_focus_out")
-      (set-frame-parameter (selected-frame) 'eaf--mac-frame
+      (set-frame-parameter (or frame (selected-frame)) 'eaf--mac-frame
                            (current-window-configuration)))
 
-    (defun eaf--mac-delete-frame-handler ()
+    (defun eaf--mac-delete-frame-handler (frame)
       (if eaf--mac-safe-focus-change
-          (eaf--mac-focus-out)
-        (eaf--mac-unsafe-focus-out)))
+          (eaf--mac-focus-out frame)
+        (eaf--mac-unsafe-focus-out frame)))
 
     (add-function :after after-focus-change-function #'eaf--mac-focus-change)
     (add-to-list 'delete-frame-functions #'eaf--mac-delete-frame-handler)))


### PR DESCRIPTION
This MR implements the `defcustom` `eaf--mac-safe-focus-change` which is set to `t` by default and which implements the behavior before https://github.com/emacs-eaf/emacs-application-framework/pull/894 was merged. The only change is that the `app-frontmost --name` shell command is cached and not called twice as before which improves application switch performance.

Setting it to `nil` implements the behavior which was implemented in https://github.com/emacs-eaf/emacs-application-framework/pull/894

This variable can be toggled on the fly.

@taquangtrung, it would be great if you could test this as well before merging this :)