### PR TITLE
Add an error message when the Emacs frame ID is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ You can use below code to load applications `browser` and `pdf-viewer` that you 
 
 #### 5. Hooray!
 
-Congratulations, you just installed EAF! You can try `M-x eaf-open-demo` (that is if you have `demo` installed, of course) to see if everything works properly, and enjoy the new possibilities of Emacs.
+Congratulations, you just installed EAF! You can try `M-x eaf-open-demo` (that is if you have `demo` installed, of course) to see if everything works properly. If the demo is installed but isn't launching, check the EAF buffer (`*eaf*`) to begin diagnosing the problem with your installation. 
 
 I **highly** encourage you to read the [Wiki](#Wiki) and [FAQ](#FAQ) if you have any questions.
 
 Also, you should regularly `git pull` **and** run `install-eaf.py` (`M-x eaf-install-and-update`) to update EAF, its applications, and relating dependencies. If you encounter a bug while using it, see the instruction on how to [Report bug](#report-bug).
+
+Enjoy the new possibilities of Emacs!
 
 ### Dependency List
 

--- a/eaf.py
+++ b/eaf.py
@@ -234,9 +234,12 @@ class EAF(object):
         if view_infos != ['']:
             for view_info in view_infos:
                 if view_info not in self.view_dict:
-                    (buffer_id, _, _, _, _, _) = view_info.split(":")
-                    view = View(self.buffer_dict[buffer_id], view_info)
-                    self.view_dict[view_info] = view
+                    (buffer_id, emacs_xid, _, _, _, _) = view_info.split(":")
+                    if emacs_xid == "nil":
+                        print("Error: Emacs frame ID return nil. Are you running Emacs in a terminal window? Try running as a GUI application instead.")
+                    else:
+                        view = View(self.buffer_dict[buffer_id], view_info)
+                        self.view_dict[view_info] = view
 
         # Call some_view_show interface when buffer's view switch back.
         # Note, this must call after new view create, otherwise some buffer,


### PR DESCRIPTION
It appears to me that EAF doesn't work when Emacs is launched from a shell. Is this a known limitation or an error in implementation? Or, is it a problem with my machine? I am running Emacs 26.3 on Ubuntu with bash version 5.0.17. When I launch Emacs from a shell, EAF functions appear and I can launch the demo `M-x eaf-open-demo`. But: I get the following message in `*eaf*`:

``` sh
Traceback (most recent call last):                                                                                                                                                                                                            
  File "/home/.../.emacs.d/site-lisp/emacs-application-framework/core/utils.py", line 61, in on_signal_received                                                                                                                          
    self._func(obj, *args, **kwargs)                                                                                                                                                                                                          
  File "/home/.../.emacs.d/site-lisp/emacs-application-framework/eaf.py", line 238, in update_views                                                                                                                                      
    view = View(self.buffer_dict[buffer_id], view_info)                                                                                                                                                                                       
  File "/home/.../.emacs.d/site-lisp/emacs-application-framework/core/view.py", line 52, in __init__                                                                                                                                     
    self.emacs_xid = int(self.emacs_xid)                                                                                                                                                                                                      
ValueError: invalid literal for int() with base 10: 'nil'       
```
However, when I launch Emacs from GUI and run the demo, I see the success message ("Hello, EAF hacker, it's working!!!").  

Anyways, I'm not sure if this is a command problem/issue/confusion. But in this PR I've added an error message that will tell the user that they should try launching Emacs via the GUI if an Emacs frame can't be found. For me, that fixed the problem. I've also added a note to `README` to suggest ways a user can diagnose problems they are having with EAF. 