### PR TITLE
Add darkreader class to markers to not be affected by dark mode

### DIFF
--- a/core/js/marker.js
+++ b/core/js/marker.js
@@ -181,7 +181,7 @@ try {
     let offsetY = "%{marker_offset_y}";
     document.head.appendChild(style);
     style.type = 'text/css';
-    style.setAttribute('class', 'eaf-style');
+    style.setAttribute('class', 'eaf-style darkreader');
     style.appendChild(document.createTextNode('\
 .eaf-mark {\
 background: none;\


### PR DESCRIPTION
Right now, the dark mode affects the markers as well.

This is with dark mode disabled:

![image](https://user-images.githubusercontent.com/15002298/147099793-926d907f-18d0-4d9f-adb7-5064fc33a7b6.png)

And this is with dark mode enabled where the markers are also affected:

![image](https://user-images.githubusercontent.com/15002298/147099815-e4907d7c-0cac-4126-8a1f-9150608e0884.png)

---

Adding the `darkreader` class ignores the markers from being affected by the dark theme.

See https://github.com/darkreader/darkreader/issues/4056#issuecomment-723554928
