### PR TITLE
Fix Printing to File on Arch

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -110,7 +110,7 @@ def get_archlinux_aur_helper():
     if command:
         return command
     else:
-        print("Please install one of AUR's helper.", file=std.err)
+        print("Please install one of AUR's helper.", file=open("std.err", 'a'))
         sys.exit(1)
 
 def install_sys_deps(distro: str, deps_list):


### PR DESCRIPTION
Basically when Arch doesn't have a helper this doesn't right to a file, it errors out saying it doesn't know what "std" is and asking if you mean "str". This fixes that so it writes to std.err