### PR TITLE
Correcting dependencies for pyqt6

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -63,14 +63,14 @@
             "epc",
             "pyqt6",
             "pyqt6-sip",
-            "pyqtwebengine",
+            "PyQt6-WebEngine",
             "pygetwindow"
         ],
         "darwin": [
             "epc",
             "pyqt6",
             "pyqt6-sip",
-            "pyqtwebengine",
+            "PyQt6-WebEngine",
             "mac-app-frontmost"
         ]
     }


### PR DESCRIPTION
pyqtwebengine was not upgraded to PyQt6-WebEngine in both windows and darwin systems during upgrade to pyqt6 in https://github.com/emacs-eaf/emacs-application-framework/commit/c3ab6a600d2fce562bd15c0e0249604d7974bbac. Considering the requirements were changed to pyqt6-webengine in other systems, I suspect this change should work.