### PR TITLE
bug fix: `eaf-install-and-update`

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1697,7 +1697,8 @@ For a full `install-eaf.py' experience, refer to `--help' and run in a terminal.
          (proc
           (progn
             (async-shell-command (concat
-                                  eaf-python-command " install-eaf.py" " --install "
+                                  eaf-python-command " install-eaf.py"
+                                  (when (length> apps 0) " --install ")
                                   (mapconcat 'symbol-name apps " "))
                                  output-buffer)
             (get-buffer-process output-buffer))))


### PR DESCRIPTION
The `--install` flag requires at least one argument, but `eaf-apps-to-install` defaults to nil.