### PR TITLE
remove dependency on `eaf-browser`

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -85,11 +85,11 @@ class BrowserView(QWebEngineView):
         (self.default_zoom, self.show_hover_link,
          self.marker_letters, self.marker_fontsize,
          self.scroll_step) = get_emacs_vars(
-            ["eaf-browser-default-zoom",
+            ["eaf-webengine-default-zoom",
              "eaf-webengine-show-hover-link",
              "eaf-marker-letters",
              "eaf-marker-fontsize",
-             "eaf-browser-scroll-step"])
+             "eaf-webengine-scroll-step"])
 
     def load_cookie(self):
         host_name = self.url().host()
@@ -818,15 +818,15 @@ class BrowserBuffer(Buffer):
          self.enable_plugin, self.enable_javascript, self.enable_scrollbar,
          self.unknown_url_scheme_policy,
          self.download_path, self.default_zoom) = get_emacs_vars(
-             ["eaf-browser-pc-user-agent",
-              "eaf-browser-phone-user-agent",
-              "eaf-browser-font-family",
-              "eaf-browser-enable-plugin",
-              "eaf-browser-enable-javascript",
-              "eaf-browser-enable-scrollbar",
-              "eaf-browser-unknown-url-scheme-policy",
-              "eaf-browser-download-path",
-              "eaf-browser-default-zoom"])
+             ["eaf-webengine-pc-user-agent",
+              "eaf-webengine-phone-user-agent",
+              "eaf-webengine-font-family",
+              "eaf-webengine-enable-plugin",
+              "eaf-webengine-enable-javascript",
+              "eaf-webengine-enable-scrollbar",
+              "eaf-webengine-unknown-url-scheme-policy",
+              "eaf-webengine-download-path",
+              "eaf-webengine-default-zoom"])
 
         self.profile = QWebEngineProfile(self.buffer_widget)
         self.profile.defaultProfile().setHttpUserAgent(self.pc_user_agent)

--- a/eaf.el
+++ b/eaf.el
@@ -409,6 +409,46 @@ been initialized."
   "Proxy Type used by EAF Browser.  The value is either \"http\" or \"socks5\"."
   :type 'string)
 
+(defcustom eaf-webengine-default-zoom 1.0
+  "Set the default zoom factor for EAF Browser."
+  :type 'float)
+
+(defcustom eaf-webengine-scroll-step 400
+  "Set the scroll step for EAF Browser, increase/decrease for bigger/smaller steps."
+  :type 'float)
+
+(defcustom eaf-webengine-pc-user-agent "Mozilla/5.0 (X11; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"
+  "Simulate a PC User-Agent for EAF Browser."
+  :type 'string)
+
+(defcustom eaf-webengine-phone-user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A5370a Safari/604.1"
+  "Simulate a Phone User-Agent for EAF Browser."
+  :type 'string)
+
+(defcustom eaf-webengine-font-family ""
+  "Set font family for EAF Browser."
+  :type 'string)
+
+(defcustom eaf-webengine-enable-plugin t
+  "If non-nil, enable QtWebEngine plugins for EAF Browser."
+  :type 'boolean)
+
+(defcustom eaf-webengine-enable-javascript t
+  "If non-nil, enable javascript for EAF Browser."
+  :type 'boolean)
+
+(defcustom eaf-webengine-enable-scrollbar nil
+  "If non-nil, enable scroll bar for EAF Browser."
+  :type 'boolean)
+
+(defcustom eaf-webengine-unknown-url-scheme-policy "AllowUnknownUrlSchemesFromUserInteraction"
+  "Allowed options: DisallowUnknownUrlSchemes, AllowUnknownUrlSchemesFromUserInteraction, or AllowAllUnknownUrlSchemes."
+  :type 'string)
+
+(defcustom eaf-webengine-download-path "~/Downloads"
+  "Set the download path for EAF Browser."
+  :type 'string)
+
 (defcustom eaf-enable-debug nil
   "If you got segfault error, please turn this option.
 Then EAF will start by gdb, please send new issue with `*eaf*' buffer content when next crash."
@@ -865,7 +905,7 @@ keybinding variable to eaf-app-binding-alist."
          (url-directory (or (file-name-directory url) url)))
     (with-current-buffer eaf-buffer
       (eaf-mode)
-      
+
       ;; Don't promt user when exist EAF python process.
       (setq-local confirm-kill-processes nil)
 


### PR DESCRIPTION
These variables are defined in `eaf-browser`, but only used in the `eaf` project, causing `eaf` to depends on `eaf-browser`, so I moved these variables to `eaf` and removed these of `eaf-browser`.

PR is here: https://github.com/emacs-eaf/eaf-browser/pull/32