### PR TITLE
fix error brought by last commit

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -826,9 +826,11 @@ When called interactively, copy to ‘kill-ring’."
   (if (derived-mode-p 'eaf-mode)
       (if (called-interactively-p 'any)
 	  (message "%s" (let ((url (eaf-call-sync "execute_function" eaf--buffer-id "get_url")))
-			  (kill-new url)
 			  (if (version< "29.0" emacs-version)
-			      url)))
+			      (progn
+				(kill-new url)
+				url)
+			    (kill-new url))))
         (eaf-call-sync "execute_function" eaf--buffer-id "get_url"))
     (user-error "This command can only be called in an EAF buffer!")))
 
@@ -1545,9 +1547,10 @@ So multiple EAF buffers visiting the same file do not sync with each other."
   (let ((confirm-function (cdr (assoc eaf-edit-confirm-action eaf-edit-confirm-function-alist))))
     (if confirm-function
         (funcal confirm-function)
-      (eaf-call-async "set_focus_text" eaf--buffer-id (eaf--encode-string (progn (kill-new (buffer-string))
-										 (if (version< "29.0" emacs-version)
-										     (buffer-string)))))))
+      (eaf-call-async "set_focus_text" eaf--buffer-id (eaf--encode-string (if (version< "29.0" emacs-version)
+									      (progn (kill-new (buffer-string))
+										     (buffer-string))
+									    (kill-new (buffer-string)))))))
 
   ;; Close confirm window.
   (kill-buffer)


### PR DESCRIPTION
Last commit breaks eaf-get-path-or-url and eaf-edit-buffer-confirm before emacs 29.