### PR TITLE
[need test] improve cookie manage

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -1548,7 +1548,12 @@ class CookiesManager(object):
             for cookie_file in os.listdir(domain_dir):
                 with open(os.path.join(domain_dir, cookie_file), "rb") as f:
                     for cookie in QNetworkCookie.parseCookies(f.read()):
-                        self.cookie_store.setCookie(cookie)
+                        name = cookie.name().data().decode("utf-8")
+                        if name.startswith("__Host-") and self.browser_view.url().host() == cookie.domain():
+                            cookie.setDomain('')
+                            self.cookie_store.setCookie(cookie, self.browser_view.url())
+                        else:
+                            self.cookie_store.setCookie(cookie)
 
     def remove_cookie(self, cookie):
         ''' Delete cookie file.'''

--- a/core/webengine.py
+++ b/core/webengine.py
@@ -1526,8 +1526,7 @@ class CookiesManager(object):
             cookie_domain = cookie_domain[1:]
 
         if not cookie.isSessionCookie():
-            cookie_name = cookie.name().data().decode("utf-8")
-            cookie_file = os.path.join(self.cookies_dir, cookie_domain, cookie_name)
+            cookie_file = os.path.join(self.cookies_dir, cookie_domain, self._generate_cookie_filename(cookie))
             touch(cookie_file)
 
             # Save newest cookie to disk.
@@ -1559,8 +1558,7 @@ class CookiesManager(object):
             cookie_domain = cookie_domain[1:]
 
         if not cookie.isSessionCookie():
-            cookie_name = cookie.name().data().decode("utf-8")
-            cookie_file = os.path.join(self.cookies_dir, cookie_domain, cookie_name)
+            cookie_file = os.path.join(self.cookies_dir, cookie_domain, self._generate_cookie_filename(cookie))
 
             if os.path.exists(cookie_file):
                 os.remove(cookie_file)
@@ -1624,3 +1622,11 @@ class CookiesManager(object):
         if cookie_domain.endswith(base_domain) and cookie_domain.removesuffix(base_domain)[-1] == '.':
             return True
         return False
+
+    def _generate_cookie_filename(self, cookie):
+        ''' Gets the name of the cookie file stored on the hard disk.'''
+        name = cookie.name().data().decode("utf-8")
+        domain = cookie.domain()
+        encode_path = cookie.path().replace("/", "|")
+
+        return name + "+" + domain + "+" + encode_path


### PR DESCRIPTION

新补丁将存储 cookie 的文件名格式改为 name+domain+path ，其中 path 中的 **/** 字符被替换为 **|** ，如 **_device_id+github.com+|**


我对这个问题理解是

- cookie domian 前缀有没有 dot 应该影响不大，都会作用于子域。

- 只有当前缀不带 dot 的 cookie 的 hostonly 属性为 true 时，coookie 才不会作用于子域。

- 可能有的网站为了兼容旧的标准就设置了 name 相同且 domain 分别带 dot 和不带 dot 的 cookie 。

这些都是浏览器负责的，问题出现的原因应该是存储时只把 cookie name 当作了唯一标识符。其实在 set cookie 时是更新已有的还是新建 cookie 会根据 cookie 的多个属性判断，如 name，domain，path。如果前面属性都一样，则 set cookie 才会更新已有的 cookie，若至少有一个属性不同则会添加一个新的 cookie 。

github 422 的原因是没有加载以 **__Host-** 开头的 cookie 文件。

根据 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie 页面中 Note: Some <cookie-name> have a specific semantic 提到的，**__Host-** 开头的 cookie name 必须设置为 host only 。

而根据 https://doc.qt.io/qt-5/qwebenginecookiestore.html#setCookie 提到的，在 QT 中设置 host only cookie 需要清空 cookie domain，添加额外 QUrl 参数。


这个补丁应该会解决 github 的 422 错误，我只测试了 点击 GitHub 通知页面 Done 按钮，可以正常工作。不知道这是不是一个通用的解决方法。