### PR TITLE
Fix wrong split-window params type.

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1715,7 +1715,7 @@ You can configure a blacklist using `eaf-find-file-ext-blacklist'"
 (defun eaf-open-devtool-page ()
   "Use EAF Browser to open the devtools page."
   (delete-other-windows)
-  (split-window (selected-window) (* (nth 3 (eaf-get-window-allocation (selected-window))) 0.618) nil t)
+  (split-window (selected-window) (round (* (nth 3 (eaf-get-window-allocation (selected-window))) 0.618)) nil t)
   (other-window 1)
   (eaf-open "about:blank" "browser" "devtools"))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13914416/174700273-65aab2c5-4326-41cb-abf9-606c6ac3015d.png)
