### PR TITLE
Ignore __pycache__ when upgrading EAF

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -308,7 +308,13 @@ def yes_no(question, default_yes=False, default_no=False):
         return key.lower() == 'y'
 
 def get_installed_apps(app_dir):
-    apps_installed = [f for f in os.listdir(app_dir) if os.path.isdir(os.path.join(app_dir, f))]
+    apps_installed = [
+        f
+        for f in os.listdir(app_dir)
+        if os.path.isdir(os.path.join(app_dir, f))
+        # directories not managed, or not part of, EAF
+        if f not in ("__pycache__",)
+    ]
     for app in apps_installed:
         git_dir = os.path.join(app_dir, app, ".git")
         if app not in get_available_apps_dict().keys():


### PR DESCRIPTION
Fixes an unhandled exception error:

```python
Traceback (most recent call last):
  File "/home/mickey/.emacs.d/packages/emacs-application-framework/./install-eaf.py", line 623, in <module>
    main()
  File "/home/mickey/.emacs.d/packages/emacs-application-framework/./install-eaf.py", line 610, in main
    install_app_deps(distro, deps_dict)
  File "/home/mickey/.emacs.d/packages/emacs-application-framework/./install-eaf.py", line 489, in install_app_deps
    apps_installed = get_installed_apps(app_dir)
  File "/home/mickey/.emacs.d/packages/emacs-application-framework/./install-eaf.py", line 425, in get_installed_apps
    apps_installed.remove(app)
ValueError: list.remove(x): x not in list
```
When upgrading an older version of EAF.

It fails because the directory list mechanism checks for directories, of which `__pycache__` is one of them. I've opted to silently ignore it during the collection of apps instead of fixing the "underlying" issue which appears to be the two if statements in `get_installed_apps()`. The first `if` statement is true and it removes `__pycache__`. The second `if` is also true and tries again to remove the already-deleted entry.

