### PR TITLE
make zoom step smaller and customizable

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -80,10 +80,11 @@ class BrowserView(QWebEngineView):
         self.focus_input_js = None
         self.simulated_wheel_event = False
 
-        (self.default_zoom, self.show_hover_link,
-         self.marker_letters, self.marker_fontsize,
-         self.scroll_step) = get_emacs_vars(
+        (self.default_zoom, self.zoom_step,
+         self.show_hover_link, self.marker_letters,
+         self.marker_fontsize, self.scroll_step) = get_emacs_vars(
             ["eaf-webengine-default-zoom",
+             "eaf-webengine-zoom-step",
              "eaf-webengine-show-hover-link",
              "eaf-marker-letters",
              "eaf-marker-fontsize",
@@ -370,7 +371,7 @@ class BrowserView(QWebEngineView):
     @interactive(insert_or_do=True)
     def zoom_in(self):
         ''' Zoom in.'''
-        self.setZoomFactor(min(5, self.zoomFactor() + 0.25))
+        self.setZoomFactor(min(5, self.zoomFactor() + self.zoom_step))
         if self.default_zoom == self.zoomFactor():
             self.buffer.zoom_data.delete_entry(urlparse(self.buffer.current_url).hostname)
         else:
@@ -379,7 +380,7 @@ class BrowserView(QWebEngineView):
     @interactive(insert_or_do=True)
     def zoom_out(self):
         ''' Zoom out.'''
-        self.setZoomFactor(max(0.25, self.zoomFactor() - 0.25))
+        self.setZoomFactor(max(0.25, self.zoomFactor() - self.zoom_step))
         if self.default_zoom == self.zoomFactor():
             self.buffer.zoom_data.delete_entry(urlparse(self.buffer.current_url).hostname)
         else:
@@ -780,7 +781,8 @@ class BrowserBuffer(Buffer):
          self.enable_scrollbar,
          self.unknown_url_scheme_policy,
          self.download_path,
-         self.default_zoom) = get_emacs_vars(
+         self.default_zoom,
+         self.zoom_step) = get_emacs_vars(
              ["eaf-webengine-pc-user-agent",
               "eaf-webengine-phone-user-agent",
               "eaf-webengine-font-family",
@@ -794,7 +796,8 @@ class BrowserBuffer(Buffer):
               "eaf-webengine-enable-scrollbar",
               "eaf-webengine-unknown-url-scheme-policy",
               "eaf-webengine-download-path",
-              "eaf-webengine-default-zoom"])
+              "eaf-webengine-default-zoom",
+              "eaf-webengine-zoom-step"])
 
         # self.profile = QWebEngineProfile(self.buffer_widget)
         # self.profile.defaultProfile() == QWebEngineProfile.defaultProfile()

--- a/eaf.el
+++ b/eaf.el
@@ -404,6 +404,10 @@ been initialized."
   "Set the default zoom factor for EAF Browser."
   :type 'float)
 
+(defcustom eaf-webengine-zoom-step 0.1
+  "Set the zoom step factor for EAF Browser."
+  :type 'float)
+
 (defcustom eaf-webengine-scroll-step 400
   "Set the scroll step for EAF Browser, increase/decrease for bigger/smaller steps."
   :type 'float)


### PR DESCRIPTION
Hi,

This is a simple PR that allows users to customize the zoom step for eaf browsers.

The default zoom step is 0.25, which is quite large, so I make it an option and set the default value to 0.1 (similar to Google Chrome)

Hope that it can be useful for EAF.