### PR TITLE
Rearrange priority of aur helpers

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -108,7 +108,7 @@ def prune_existing_sys_deps(deps_list):
 
 def get_archlinux_aur_helper():
     command = None
-    for helper in ["pacaur", "yay", "yaourt", "paru"]:
+    for helper in ["paru", "pacaur", "yay", "yaourt"]:
         if which(helper):
             command = helper
             break


### PR DESCRIPTION
优先使用paru

yay不支持用--needed跳过aur的包，这就导致即使已经手动安装上filebrowser-bin，yay也会自动再装一遍，如果这个自动安装失败了（国内网络不稳定），就会使得依赖它的eaf应用误认为依赖安装失败，从而拒绝安装。

实测paru是支持用--needed跳过aur的包的。所以调整顺序，优先使用paru。

当然这只是权宜之计。比如没用包管理器，而是手动将装这些依赖装在某个$PATH比如/usr/bin/里，那这个仅仅调整aur helper优先级的方法也还是会失效。

最好的方法应当还是让安装过程直接检测系统中的executables是否存在，而不是包管理器判断packages是否安装成功。我不会python，就暂时不作进一步修改了。