### PR TITLE
darkreader.js背景色设置

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -741,9 +741,11 @@ class BrowserView(QWebEngineView):
 
         if dark_mode_theme == "dark":
             dark_mode_custom_theme["mode"] = 1
-            self.dark_mode_js += """DarkReader.enable(%s);""" % json.dumps(dark_mode_custom_theme)
         else: # light theme
-            self.dark_mode_js += """DarkReader.enable({brightness: 100, contrast: 90, sepia: 10, mode: 0});"""
+            dark_mode_custom_theme["mode"] = 0
+
+        self.dark_mode_js += """DarkReader.enable(%s);""" % json.dumps(dark_mode_custom_theme)
+
 
 class BrowserPage(QWebEnginePage):
     def __init__(self):


### PR DESCRIPTION
目前darkreader.js的背景色有一点偏灰白，强迫症患者难以接受。
查看darkreader代码，发现是调用时sepia, constrast 以及brightness三个值的设定影响的。
因此加入一个参数到init_dark_mode_js，以实现自定义的darkScheme主题色设置。