### PR TITLE
fix: hyprland's focus

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1644,7 +1644,10 @@ So multiple EAF buffers visiting the same file do not sync with each other."
           ;; Emacs window cannot get the focus normally if mouse in EAF buffer area.
           ;;
           ;; So we move mouse to frame bottom of Emacs, to make EAF receive input event.
-          (eaf-call-async "eval_function" (or eaf--buffer-id buffer_id) "move_cursor_to_corner" (key-description (this-command-keys-vector)))
+          (cond ((string-equal (getenv "XDG_CURRENT_DESKTOP") "Hyprland")
+                 (shell-command-to-string "hyprctl dispatch focuswindow Emacs"))
+                (t
+                 (eaf-call-async "eval_function" (or eaf--buffer-id buffer_id) "move_cursor_to_corner" (key-description (this-command-keys-vector)))))
 
         ;; Activate the window by `wmctrl' when possible
         (if (executable-find "wmctrl")


### PR DESCRIPTION
Wayland 上不能设置鼠标的位置，因此用 `hyprctl` 改变聚焦的窗口。