### PR TITLE
fix: Hyprland window alignment

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -249,6 +249,25 @@ def handle_arg_types(arg):
 
     return sexpdata.Quoted(arg)
 
+def hyprland_window_move(x, y):
+    import subprocess
+    import json
+
+    clients = json.loads(subprocess.check_output("hyprctl -j clients", shell=True))
+    window_info = []
+
+    for window in clients:
+        if window["title"] == "eaf.py":
+            window_info = window["at"]
+            break
+
+    if len(window_info) == 0:
+        return
+
+    [window_x, window_y] = window_info
+
+    if not (x - window_x == 0 and y - window_y == 0):
+        subprocess.check_call(f"hyprctl dispatch movewindowpixel '{x - window_x} {y - window_y}','title:^(eaf.py)$'", shell=True)
 
 def eval_in_emacs(method_name, args):
     global epc_client

--- a/core/utils.py
+++ b/core/utils.py
@@ -266,7 +266,7 @@ def hyprland_window_move(x, y):
 
     [window_x, window_y] = window_info
 
-    if not (x - window_x == 0 and y - window_y == 0):
+    if (x - window_x == 0 and y - window_y == 0) is False:
         subprocess.check_call(f"hyprctl dispatch movewindowpixel '{x - window_x} {y - window_y}','title:^(eaf.py)$'", shell=True)
 
 def eval_in_emacs(method_name, args):

--- a/core/utils.py
+++ b/core/utils.py
@@ -266,7 +266,7 @@ def hyprland_window_move(x, y):
 
     [window_x, window_y] = window_info
 
-    if (x - window_x == 0 and y - window_y == 0) is False:
+    if x - window_x != 0 or y - window_y != 0:
         subprocess.check_call(f"hyprctl dispatch movewindowpixel '{x - window_x} {y - window_y}','title:^(eaf.py)$'", shell=True)
 
 def eval_in_emacs(method_name, args):

--- a/core/view.py
+++ b/core/view.py
@@ -22,7 +22,7 @@
 from PyQt6.QtCore import Qt, QEvent, QPoint
 from PyQt6.QtGui import QPainter, QWindow, QBrush
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QGraphicsView, QFrame
-from core.utils import eval_in_emacs, focus_emacs_buffer, get_emacs_func_cache_result
+from core.utils import eval_in_emacs, focus_emacs_buffer, get_emacs_func_cache_result, hyprland_window_move
 
 class View(QWidget):
 
@@ -105,8 +105,12 @@ class View(QWidget):
     def eventFilter(self, obj, event):
         # import time
         # print(time.time(), event.type())
-        
+
         import platform
+        import os
+
+        if os.getenv("XDG_CURRENT_DESKTOP") == "Hyprland":
+            hyprland_window_move(self.x, self.y)
 
         if event.type() in [QEvent.Type.ShortcutOverride]:
             eval_in_emacs('eaf-activate-emacs-window', [self.buffer_id])
@@ -126,7 +130,7 @@ class View(QWidget):
     def showEvent(self, event):
         # NOTE: we must reparent after widget show, otherwise reparent operation maybe failed.
         import platform
-        
+
         self.reparent()
 
         if platform.system() in ["Windows", "Darwin"]:

--- a/core/view.py
+++ b/core/view.py
@@ -109,7 +109,7 @@ class View(QWidget):
         import platform
         import os
 
-        if os.getenv("XDG_CURRENT_DESKTOP") == "Hyprland":
+        if os.getenv("XDG_CURRENT_DESKTOP") == "Hyprland" and event.type() in [QEvent.Type.Enter]:
             hyprland_window_move(self.x, self.y)
 
         if event.type() in [QEvent.Type.ShortcutOverride]:

--- a/core/view.py
+++ b/core/view.py
@@ -27,6 +27,8 @@ from core.utils import eval_in_emacs, focus_emacs_buffer, get_emacs_func_cache_r
 class View(QWidget):
 
     def __init__(self, buffer, view_info):
+        import os
+
         super(View, self).__init__()
 
         self.buffer = buffer
@@ -50,6 +52,7 @@ class View(QWidget):
         self.y: int = int(self.y)
         self.width: int = int(self.width)
         self.height: int = int(self.height)
+        self.desktop = os.getenv("XDG_CURRENT_DESKTOP")
 
         # Build QGraphicsView.
         self.layout: QVBoxLayout = QVBoxLayout(self)
@@ -107,9 +110,8 @@ class View(QWidget):
         # print(time.time(), event.type())
 
         import platform
-        import os
 
-        if os.getenv("XDG_CURRENT_DESKTOP") == "Hyprland" and event.type() in [QEvent.Type.Enter]:
+        if self.desktop == "Hyprland" and event.type() in [QEvent.Type.Enter]:
             hyprland_window_move(self.x, self.y)
 
         if event.type() in [QEvent.Type.ShortcutOverride]:


### PR DESCRIPTION
Hyprland 上设置窗口大小会导致窗口坐标发生变化，可能因此挡住一部分标签栏。

我尝试使用 move 方法改变窗口位置，但是无效。这个补丁使用 `hyprctl` 实现改变窗口位置。