### PR TITLE
use start hook to always configure topmost setting for macOS

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1450,7 +1450,7 @@ WEBENGINE-INCLUDE-PRIVATE-CODEC is only useful when app-name is video-player."
 
 (defun eaf--rebuild-buffer ()
   (when (derived-mode-p 'eaf-mode)
-    (eaf-start-process)
+    (eaf-restart-process)
     (eaf--open-new-buffer (current-buffer))
     (eaf-monitor-configuration-change)))
 


### PR DESCRIPTION
Hi,

This PR enables EAF to always configure topmost Python app settings in macOS every time EAF is restarted.
Currently, that setting is only configure when EAF starts for the first time, but not when it is restarted.

Can you review the PR and merge it?
Thanks!