### PR TITLE
pass --break-system-packages to pip for EXTERNALLY-MANAGED installations

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+import sysconfig
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--install-all-apps", action="store_true",
@@ -142,7 +143,11 @@ def install_sys_deps(distro: str, deps_list):
 
 def install_py_deps(deps_list):
     if sys.prefix == sys.base_prefix:
-        command = [PIP_CMD, 'install', '--user', '-U']
+        # pass --break-system-packages to permit installing packages into EXTERNALLY-MANAGED Python installations. see https://github.com/pypa/pip/issues/11780
+        if os.path.exists(os.path.join(sysconfig.get_path("stdlib", sysconfig.get_default_scheme()),"EXTERNALLY-MANAGED")):
+            command = [PIP_CMD, 'install', '--user', '--break-system-packages', '-U']
+        else:
+            command = [PIP_CMD, 'install', '--user', '-U']
     else:
         # if running on a virtual env, --user option is not valid.
         command = [PIP_CMD, 'install', '-U']


### PR DESCRIPTION
For pip 23.0.1, a flag --break-system-packages should be passed to pip install --user to install a package on an EXTERNALLY-MANAGED python system. Please see [Implement --break-system-packages for EXTERNALLY-MANAGED installations](https://github.com/pypa/pip/pull/11780) and [PEP 668 – Marking Python base environments as “externally managed”](https://peps.python.org/pep-0668/#specification) for description of EXTERNALLY-MANAGED system. 