### PR TITLE
Make `eaf-kill-process` kill really /all/ processes.

### DIFF
--- a/core/eaf-epc.el
+++ b/core/eaf-epc.el
@@ -762,5 +762,10 @@ This variable is used for the management purpose.")
           eaf-epc-server-processes)
     main-process))
 
+(defun eaf-epc-stop-server-processes ()
+  (dolist (proc eaf-epc-server-processes)
+    (delete-process (car proc)))
+  (sleep-for .3))
+
 (provide 'eaf-epc)
 ;;; eaf-epc.el ends here

--- a/eaf.el
+++ b/eaf.el
@@ -742,7 +742,8 @@ If RESTART is non-nil, cached URL and app-name will not be cleared."
     (message "[EAF] Killed %s EAF buffer%s" count (if (> count 1) "s!" "!")))
 
   ;; Kill process after kill buffer, make application can save session data.
-  (eaf--kill-python-process))
+  (eaf--kill-python-process)
+  (eaf-epc-stop-server-processes))
 
 (defalias 'eaf-stop-process #'eaf-kill-process)
 


### PR DESCRIPTION
Relates to #1096.