### PR TITLE
Fix `eaf-mail` for new versions of `mu4e`

### DIFF
--- a/extension/eaf-mail.el
+++ b/extension/eaf-mail.el
@@ -122,7 +122,7 @@
 
 (defun eaf-mu4e-get-html ()
   "Retrieve HTML part of a mu4e mail."
-  (let ((msg mu4e~view-message))
+  (let ((msg (or (bound-and-true-p mu4e~view-message) mu4e--view-message)))
     (mu4e-message-field msg :body-html)))
 
 (defun eaf-notmuch-get-html ()


### PR DESCRIPTION
Fix `eaf-mu4e-get-html`. New versions of `mu4e` renamed `mu4e~view-message` to `mu4e--view-message`. This PR fixes the issue for new versions while supporting the old ones.