### PR TITLE
remove self from print_warning_message

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -515,7 +515,7 @@ def install_app_deps(distro, deps_dict):
     else:
         print("[EAF] Please rerun ./install-eaf.py with `--force`, or install them manually!")
 
-def print_warning_message(self, message):
+def print_warning_message(message):
     print(bcolors.WARNING + message + bcolors.ENDC)
 
 def main():


### PR DESCRIPTION
Some error messages shows after run `eaf-install-and-update`:

```
Traceback (most recent call last):
  File "~/.emacs.d/site-lisp/emacs-application-framework/install-eaf.py", line 547, in <module>
    main()
  File "~/.emacs.d/site-lisp/emacs-application-framework/install-eaf.py", line 540, in main
    print_warning_message(msg)
TypeError: print_warning_message() missing 1 required positional argument: 'message'
```