### PR TITLE
Support Unity desktop for some old ubuntu systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ There are four types of support for the Wayland environment:
 - Sway Wayland Native: jq needs to be installed
 - Hyprland Wayland Native
 
+Unity environment support: requires `xdotool` to be installed.
+
 #### 3. Load EAF Core
 
 From here on, you can add the full path to the EAF installation directory to your Emacs ```load-path```, then add the following to `init.el`:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,8 @@ Wayland 环境的支持分四种情况：
 - Sway Wayland Native： 需要安装 jq
 - Hyprland Wayland Native
 
+Unity 桌面环境支持： 需要安装xdotool
+
 #### 3. 加载 EAF 核心
 
 从这里开始， 你可以把 EAF 加入 Emacs 的 ```load-path```， 然后在 `init.el` 中写入:

--- a/eaf.el
+++ b/eaf.el
@@ -1055,6 +1055,9 @@ provide at least one way to let everyone experience EAF. ;)"
 (defun eaf--on-hyprland-p ()
   (string-equal (getenv "XDG_CURRENT_DESKTOP") "Hyprland"))
 
+(defun eaf--on-unity-p ()
+  (string-equal (getenv "XDG_CURRENT_DESKTOP") "Unity"))
+
 (defun eaf--on-sway-p ()
   (string-equal (getenv "XDG_SESSION_DESKTOP") "sway"))
 
@@ -1075,6 +1078,10 @@ provide at least one way to let everyone experience EAF. ;)"
                            (or
                             (gethash "class" (json-parse-string (shell-command-to-string "hyprctl -j activewindow")))
                             ""))
+                          ((eaf--on-unity-p)
+                           (if (executable-find "xdotool")
+                               (shell-command-to-string "xdotool getactivewindow getwindowname")
+                             (message "Please install xdotool for Unity support.")))
                           (t
                            (require 'dbus)
                            (dbus-call-method :session "org.gnome.Shell" "/org/eaf/wayland" "org.eaf.wayland" "get_active_window" :timeout 1000))))


### PR DESCRIPTION
I get the following error when using EAF on some older machines (the system is Ubuntu 16.04):

And it seems that Unity's desktop doesn't support `gnome-extensions`

![image](https://github.com/emacs-eaf/emacs-application-framework/assets/13914416/b5c3a6b4-08c1-4dec-8f2e-7bda7c86f09b)
