### PR TITLE
Improve input focus and retry mechanism

### DIFF
--- a/core/js/focus_input.js
+++ b/core/js/focus_input.js
@@ -25,10 +25,11 @@
     var cssSelector = "input";
 
     var elements = getVisibleElements(function(e, v) {
-        if (e.matches(cssSelector) && !e.disabled && !e.readOnly
-            && (e.type === "text" || e.type === "search" || e.type === "password")) {
+	if ((e.matches('input') && !e.disabled && !e.readOnly && 
+             (e.type === "text" || e.type === "search" || e.type === "password")) || 
+            e.matches('textarea') && !e.disabled && !e.readOnly) {
             v.push(e);
-        }
+	}
     });
 
     if (elements.length === 0 && document.querySelector(cssSelector) !== null) {

--- a/core/webengine.py
+++ b/core/webengine.py
@@ -1434,7 +1434,14 @@ class BrowserBuffer(Buffer):
         if text is not None:
             atomic_edit(self.buffer_id, text)
         else:
-            message_to_emacs("No active input element.")
+            self.buffer_widget.focus_input()
+
+            # try again:
+            text = self.buffer_widget.get_focus_text()
+            if text is not None:
+                atomic_edit(self.buffer_id, text)
+            else:
+                message_to_emacs("No active input element.")
 
     @interactive
     def switch_to_input_mode(self):


### PR DESCRIPTION
This commit enhances the input focus functionality by extending support to include textarea elements alongside input elements in focus_input.js. It also introduces a retry mechanism in webengine.py for instances where the initial focus attempt fails, ensuring a more reliable focus on input elements.