### PR TITLE
fixed nix dependency for wmctrl

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -15,7 +15,7 @@
     "node"
   ],
   "nix": [
-    "wmctrl",
+    "nixpkgs#wmctrl",
     "node"
   ],
   "emerge": [


### PR DESCRIPTION
at least for me wmctrl fails to fetch with nix profiles install without nixpkgs# in front of it. But I did not test if this is just because I have nix command and flakes enabled.