### PR TITLE
fixed nix dependency for nodejs

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -16,7 +16,7 @@
   ],
   "nix": [
     "nixpkgs#wmctrl",
-    "node"
+    "nixpkgs#nodejs"
   ],
   "emerge": [
     "x11-misc/wmctrl",


### PR DESCRIPTION
just realized nodejs had the same problem as wmctrl and thought I should fix it.
I don't know why this didn't make a problem while installing it on nixos like wmctrl did but I think it is better to change it nonetheless.
I just tested if nix profile install node worked and, surprise it didn't but nix profile install nixpkgs#nodejs seems to work fine. At least when manually doing it.