### PR TITLE
Make it no query to kill processes when quit emacs

### DIFF
--- a/core/eaf-epc.el
+++ b/core/eaf-epc.el
@@ -701,6 +701,7 @@ This variable is used for the management purpose.")
     (set-process-filter process
                         (lambda (p m)
                           (eaf-epc-process-filter connection p m)))
+    (set-process-query-on-exit-flag process nil)
     (set-process-sentinel process
                           (lambda (p e)
                             (eaf-epc-process-sentinel connection p e)))
@@ -751,6 +752,7 @@ This variable is used for the management purpose.")
          :server t
          :host "127.0.0.1"
          :service (or port t)
+         :noquery t
          :sentinel
          (lambda (process message)
            (eaf-epc-server-sentinel process message connect-function)))))


### PR DESCRIPTION
EAF has two processes that need query to kill when quit emacs, but holo-layer doesn't have. I think no needs of query is right. So I compare the code between them and modify the EAF.