### PR TITLE
Ensure EAF works in i3wm when not in fullscreen mode

### DIFF
--- a/core/buffer.py
+++ b/core/buffer.py
@@ -214,6 +214,31 @@ class Buffer(QGraphicsScene):
             # Sometimes, setPos(QScreen, Int, Int) API don't exists.
             QCursor().setPos(screen.size().width() - 1, screen.size().height() - 1)
 
+    def move_cursor_to_nearest_border(self):
+        '''
+        Move cursor to nearest border of current buffer.
+        '''
+        # get current cursor position
+        cursor_pos = QCursor().pos()
+        # get current screen
+        screen = QApplication.instance().primaryScreen()    # type: ignore
+
+        c_x, c_y = cursor_pos.x(), cursor_pos.y()
+        sc_width, sc_height = screen.size().width(), screen.size().height()
+        left_dist, right_dist = c_x, sc_width - c_x
+        top_dist, bottom_dist = c_y, sc_height - c_y
+        min_dist = min(left_dist, right_dist, top_dist, bottom_dist)
+
+        # move cursor to nearest border
+        if min_dist == left_dist:
+            QCursor().setPos(0, c_y)
+        elif min_dist == right_dist:
+            QCursor().setPos(sc_width-1, c_y)
+        elif min_dist == top_dist:
+            QCursor().setPos(c_x, 0)
+        elif min_dist == bottom_dist:
+            QCursor().setPos(c_x, sc_height-1)
+        
     def set_aspect_ratio(self, aspect_ratio):
         ''' Set aspect ratio.'''
         self.aspect_ratio = aspect_ratio

--- a/eaf.el
+++ b/eaf.el
@@ -1786,19 +1786,19 @@ So multiple EAF buffers visiting the same file do not sync with each other."
     (if (or (member "LUCID" system-configuration-arguments)
             (member "ATHENA" system-configuration-arguments))
         (message "Please compile emacs use option --with-x-toolkit=gtk3, otherwise EAF can't focus emacs window expected.")
-      (if eaf-is-member-of-focus-fix-wms
+      (when eaf-is-member-of-focus-fix-wms
           ;; When switch app focus in WM, such as, i3 or qtile.
           ;; Emacs window cannot get the focus normally if mouse in EAF buffer area.
           ;;
-          ;; So we move mouse to frame bottom of Emacs, to make EAF receive input event.
+          ;; So we move mouse out of Emacs to the nearest outter border, then refocus on Emacs winodw.
 	  (if (eaf--on-hyprland-p)
 	      (shell-command (format "hyprctl dispatch focuswindow pid:%d" (emacs-pid)))
-	    (eaf-call-async "eval_function" (or eaf--buffer-id buffer_id) "move_cursor_to_corner" (key-description (this-command-keys-vector))))
-
+	    (eaf-call-async "eval_function" (or eaf--buffer-id buffer_id) "move_cursor_to_nearest_border" (key-description (this-command-keys-vector)))))
+    
         ;; Activate the window by `wmctrl' when possible
         (if (executable-find "wmctrl")
             (shell-command-to-string (format "wmctrl -i -a $(wmctrl -lp | awk -vpid=$PID '$3==%s {print $1; exit}')" (emacs-pid)))
-          (message "Please install wmctrl to active Emacs window."))))))
+          (message "Please install wmctrl to active Emacs window.")))))
 
 (defun eaf--activate-emacs-mac-window()
   "Activate Emacs macOS window."


### PR DESCRIPTION
As described in eaf.el:

>           ;; When switch app focus in WM, such as, i3 or qtile.
>           ;; Emacs window cannot get the focus normally if mouse in EAF buffer area.
>           ;;
>           ;; So we move mouse to frame bottom of Emacs, to make EAF receive input event.

However, it doesn't work when the Emacs window is not in fullscreen mode (e.g., in a floating mode, windows with gaps or a vertical split workspace, where Emacs is on the left and another app is on the right) .

This commit introduces another workaround where the cursor is first moved out of the Emacs window, positioning it near the screen border . then it calls wmctrl to refocus the Emacs  window.