### PR TITLE
Fix issue #1169.

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -312,6 +312,12 @@ Note, we need hook this function to signal 'loadProgress', signal 'loadStarted' 
                 else:
                     self.zoom_out()
 
+        if event.type() == QEvent.Type.MouseButtonRelease and \
+           event.button() in [Qt.MouseButton.ForwardButton,
+                              Qt.MouseButton.BackButton]:
+            event.accept()
+            return True
+
         return super(QWebEngineView, self).eventFilter(obj, event)
 
     def translate_cursor_word(self, word):


### PR DESCRIPTION
I catch the event with "mouse-release" type and "forward/back" button at the end of the `eventFilter` method, do nothing and return true. This can fix the issue #1169, but I am not sure it is the best practice.