### PR TITLE
Fix compilation error.

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1049,31 +1049,32 @@ Including title-bar, menu-bar, offset depends on window system, and border."
       (+ (eaf--frame-top frame) (eaf--frame-internal-height frame))
     0))
 
-(defun eaf-emacs-not-use-reparent-technology ()
-  "When Emacs running in macOS、Wayland native or terminal environment,
+(eval-when-compile
+
+  (defun eaf-emacs-not-use-reparent-technology ()
+    "When Emacs running in macOS、Wayland native or terminal environment,
 we can't use 'cross-process reparent' technicality like we does in X11, XWayland or Windows.
 
 In this situation, we use 'stay on top' technicality that show EAF window when Emacs get focus, hide EAF window when Emacs lost focus.
 
 'Stay on top' technicality is not perfect like 'cross-process reparent' technicality,
 provide at least one way to let everyone experience EAF. ;)"
-  (or (eq system-type 'darwin)              ;macOS
-      (eaf-emacs-running-in-wayland-native) ;Wayland native
-      ))
+    (or (eq system-type 'darwin)              ;macOS
+        (eaf-emacs-running-in-wayland-native) ;Wayland native
+        ))
 
-(defun eaf-emacs-running-in-wayland-native ()
-  (eq window-system 'pgtk))
+  (defun eaf-emacs-running-in-wayland-native ()
+    (eq window-system 'pgtk))
 
-(defun eaf--on-hyprland-p ()
-  (string-equal (getenv "XDG_CURRENT_DESKTOP") "Hyprland"))
+  (defun eaf--on-hyprland-p ()
+    (string-equal (getenv "XDG_CURRENT_DESKTOP") "Hyprland"))
 
-(defun eaf--on-unity-p ()
-  (string-equal (getenv "XDG_CURRENT_DESKTOP") "Unity"))
+  (defun eaf--on-unity-p ()
+    (string-equal (getenv "XDG_CURRENT_DESKTOP") "Unity"))
 
-(defun eaf--on-sway-p ()
-  (string-equal (getenv "XDG_SESSION_DESKTOP") "sway"))
+  (defun eaf--on-sway-p ()
+    (string-equal (getenv "XDG_SESSION_DESKTOP") "sway"))
 
-(eval-when-compile
   (when (eaf-emacs-not-use-reparent-technology)
     (defvar eaf--topmost-switch-to-python nil
       "Record if Emacs should switch to Python process.")


### PR DESCRIPTION
Now the elisp file gets compilation error:

```
Error: void-function (eaf-emacs-not-use-reparent-technology)
  eaf-emacs-not-use-reparent-technology()
  byte-code("\300 \205A\0\301\302\303\304#\210\305\306\307\"\210\305\310\311\"\210\305\312\313\"\210\305\314\315\"\210\305\316\31>
  eval((byte-code "\300 \205A\0\301\302\303\304#\210\305\306\307\"\210\305\310\311\"\210\305\312\313\"\210\305\314\315\"\210\305\>
  byte-compile-eval((byte-code "\300 \205A\0\301\302\303\304#\210\305\306\307\"\210\305\310\311\"\210\305\312\313\"\210\305\314\3>
  #f(compiled-function (form) #<bytecode 0x15e307b3098c1aaf>)((if (eaf-emacs-not-use-reparent-technology) (progn (defvar eaf--top>
  byte-compile-recurse-toplevel((when (eaf-emacs-not-use-reparent-technology) (defvar eaf--topmost-switch-to-python nil "Record i>
  #f(compiled-function (&rest body) #<bytecode -0xf044c570cfb2fef>)((when (eaf-emacs-not-use-reparent-technology) (defvar eaf--to>
  macroexpand-1((eval-when-compile (when (eaf-emacs-not-use-reparent-technology) (defvar eaf--topmost-switch-to-python nil "Recor>
  macroexp-macroexpand((eval-when-compile (when (eaf-emacs-not-use-reparent-technology) (defvar eaf--topmost-switch-to-python nil>
  byte-compile-recurse-toplevel((eval-when-compile (when (eaf-emacs-not-use-reparent-technology) (defvar eaf--topmost-switch-to-p>
  byte-compile-toplevel-file-form((eval-when-compile (when (eaf-emacs-not-use-reparent-technology) (defvar eaf--topmost-switch-to>
  #f(compiled-function () #<bytecode 0xabc883594f567b>)()
  bytecomp--displaying-warnings(#f(compiled-function () #<bytecode 0xabc883594f567b>))
  byte-compile-from-buffer(#<buffer  *Compiler Input*>)
  byte-compile-file("/nix/store/2lwjpsyq4nxpsc1vf0wwi9v93ays5sp3-emacs-eaf-0-unstable-2025-07-26/share/emacs/site-lisp/elpa/eaf-2>
  byte-recompile-file("/nix/store/2lwjpsyq4nxpsc1vf0wwi9v93ays5sp3-emacs-eaf-0-unstable-2025-07-26/share/emacs/site-lisp/elpa/eaf>
  #f(compiled-function () #<bytecode -0x6b66ff5321984bc>)()
  bytecomp--displaying-warnings(#f(compiled-function () #<bytecode -0x6b66ff5321984bc>))
  byte-recompile-directory("/nix/store/2lwjpsyq4nxpsc1vf0wwi9v93ays5sp3-emacs-eaf-0-unstable-2025-07-26/share/emacs/site-lisp/elp>
  package--compile(#s(package-desc :name eaf :version (20250726 0) :summary "Emacs application framework." :reqs nil :kind nil :a>
  package-unpack(#s(package-desc :name eaf :version (20250726 0) :summary "Emacs application framework." :reqs nil :kind tar :arc>
  (let ((pkg-desc (if (derived-mode-p 'tar-mode) (package-tar-file-info) (package-buffer-info)))) (package-unpack pkg-desc) pkg-d>
  elpa2nix-install-from-buffer()
  (progn (if is-tar (insert-file-contents-literally file) (insert-file-contents file)) (if is-tar (progn (tar-mode))) (elpa2nix-i>
  (unwind-protect (progn (if is-tar (insert-file-contents-literally file) (insert-file-contents file)) (if is-tar (progn (tar-mod>
  (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn (if is-tar (insert-file-contents-literally file) (insert-f>
  (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn (if>
  (let ((is-tar (string-match "\\.tar\\'" file))) (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current-buffer (se>
  elpa2nix-install-file("/build/packages/eaf-20250726.0.tar")
  (progn (setq byte-compile-error-on-warn (string= turn-compilation-warning-to-error "t")) (setq byte-compile-debug (string= igno>
  (let ((archive x0) (elpa x2) (turn-compilation-warning-to-error x4) (ignore-compilation-error x6)) (progn (setq byte-compile-er>
  (if (null x7) (let ((archive x0) (elpa x2) (turn-compilation-warning-to-error x4) (ignore-compilation-error x6)) (progn (setq b>
  (let* ((x6 (car-safe x5)) (x7 (cdr-safe x5))) (if (null x7) (let ((archive x0) (elpa x2) (turn-compilation-warning-to-error x4)>
  (if (consp x5) (let* ((x6 (car-safe x5)) (x7 (cdr-safe x5))) (if (null x7) (let ((archive x0) (elpa x2) (turn-compilation-warni>
  (let* ((x4 (car-safe x3)) (x5 (cdr-safe x3))) (if (consp x5) (let* ((x6 (car-safe x5)) (x7 (cdr-safe x5))) (if (null x7) (let (>
  (if (consp x3) (let* ((x4 (car-safe x3)) (x5 (cdr-safe x3))) (if (consp x5) (let* ((x6 (car-safe x5)) (x7 (cdr-safe x5))) (if (>
  (let* ((x2 (car-safe x1)) (x3 (cdr-safe x1))) (if (consp x3) (let* ((x4 (car-safe x3)) (x5 (cdr-safe x3))) (if (consp x5) (let*>
  (if (consp x1) (let* ((x2 (car-safe x1)) (x3 (cdr-safe x1))) (if (consp x3) (let* ((x4 (car-safe x3)) (x5 (cdr-safe x3))) (if (>
  (let* ((x0 (car-safe command-line-args-left)) (x1 (cdr-safe command-line-args-left))) (if (consp x1) (let* ((x2 (car-safe x1)) >
  (if (consp command-line-args-left) (let* ((x0 (car-safe command-line-args-left)) (x1 (cdr-safe command-line-args-left))) (if (c>
  elpa2nix-install-package()
  command-line-1(("-l" "/nix/store/3dqdl3w07k2amg65q61q15qm6wanmfac-elpa2nix.el" "-f" "elpa2nix-install-package" "/build/packages>
  command-line()
  normal-top-level()
Symbol's function definition is void: eaf-emacs-not-use-reparent-technology
```

Move the definition of the function `eaf-emacs-not-use-reparent-technology` into `eval-when-compile` block can solve this problem.