### PR TITLE
Replace the `app-frontmost` dependency with native AppleScript.

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1083,7 +1083,7 @@ provide at least one way to let everyone experience EAF. ;)"
     (defun eaf--topmost-focus-change ()
       "Manage Emacs's focus change."
       (let* ((front (cond ((eq system-type 'darwin)
-                           (shell-command-to-string "app-frontmost --name"))
+                           (string-trim (shell-command-to-string "osascript -e 'tell application \"System Events\" to get name of first application process whose frontmost is true'")))
                           ((eaf--on-sway-p)
                            (if (executable-find "jq")
                                (shell-command-to-string "swaymsg -t get_tree | jq -r '..|try select(.focused == true).app_id'")


### PR DESCRIPTION
#1182 

- Use `osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true'` to detect the currently active application.
- Support runs natively from Mac OS X 10.3（2003） up to latest macOS on both Intel and Apple Silicon, with no additional software required